### PR TITLE
Move from string-based links and joints to id-based logic (using hashes)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,15 @@ target_compile_definitions(${PROJECT_NAME}_trac-ik PRIVATE TESSERACT_KINEMATICS_
 #   add_subdirectory(test)
 # endif()
 
+# Benchmarks (opt-in — pulls rclcpp and ROS interface libraries through trac_ik_lib).
+# Defaults to ON whenever the workspace-wide TESSERACT_ENABLE_BENCHMARKING flag is set,
+# so ./colcon_tesseract.sh builds this benchmark alongside the core ones.
+# option(TESSERACT_TRAC_IK_ENABLE_BENCHMARKING "Build the Trac-IK vs RTP/KDL benchmark"
+#        ${TESSERACT_ENABLE_BENCHMARKING})
+# if(TESSERACT_TRAC_IK_ENABLE_BENCHMARKING AND TESSERACT_BUILD_TRACIK)
+#   add_subdirectory(test/benchmarks)
+# endif()
+
 configure_package(COMPONENT trac-ik SUPPORTED_COMPONENTS ${SUPPORTED_COMPONENTS})
 
 if(TESSERACT_PACKAGE)

--- a/tesseract_kinematics/trac-ik/CMakeLists.txt
+++ b/tesseract_kinematics/trac-ik/CMakeLists.txt
@@ -24,7 +24,8 @@ target_link_libraries(
          console_bridge::console_bridge)
 target_compile_options(${PROJECT_NAME}_trac-ik PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})
 target_compile_options(${PROJECT_NAME}_trac-ik PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
-target_compile_definitions(${PROJECT_NAME}_trac-ik PUBLIC ${TESSERACT_COMPILE_DEFINITIONS})
+target_compile_definitions(${PROJECT_NAME}_trac-ik PRIVATE ${TESSERACT_COMPILE_DEFINITIONS_PRIVATE})
+target_compile_definitions(${PROJECT_NAME}_trac-ik PUBLIC ${TESSERACT_COMPILE_DEFINITIONS_PUBLIC})
 target_clang_tidy(${PROJECT_NAME}_trac-ik ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_trac-ik PUBLIC VERSION ${TESSERACT_CXX_VERSION})
 target_code_coverage(
@@ -46,7 +47,8 @@ target_link_libraries(
          console_bridge::console_bridge)
 target_compile_options(${PROJECT_NAME}_trac-ik_factory PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})
 target_compile_options(${PROJECT_NAME}_trac-ik_factory PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
-target_compile_definitions(${PROJECT_NAME}_trac-ik_factory PUBLIC ${TESSERACT_COMPILE_DEFINITIONS})
+target_compile_definitions(${PROJECT_NAME}_trac-ik_factory PRIVATE ${TESSERACT_COMPILE_DEFINITIONS_PRIVATE})
+target_compile_definitions(${PROJECT_NAME}_trac-ik_factory PUBLIC ${TESSERACT_COMPILE_DEFINITIONS_PUBLIC})
 target_clang_tidy(${PROJECT_NAME}_trac-ik_factory ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_trac-ik_factory PUBLIC VERSION ${TESSERACT_CXX_VERSION})
 target_code_coverage(

--- a/tesseract_kinematics/trac-ik/include/tesseract_trac_ik/trac-ik/trac-ik_inv_kin_chain.h
+++ b/tesseract_kinematics/trac-ik/include/tesseract_trac_ik/trac-ik/trac-ik_inv_kin_chain.h
@@ -98,11 +98,11 @@ public:
                   const tesseract::common::LinkIdTransformMap& tip_link_poses,
                   const Eigen::Ref<const Eigen::VectorXd>& seed) const override final;
 
-  std::vector<std::string> getJointNames() const override final;
+  std::vector<tesseract::common::JointId> getJointIds() const override final;
   Eigen::Index numJoints() const override final;
-  std::string getBaseLinkName() const override final;
-  std::string getWorkingFrame() const override final;
-  std::vector<std::string> getTipLinkNames() const override final;
+  tesseract::common::LinkId getBaseLinkId() const override final;
+  tesseract::common::LinkId getWorkingFrameId() const override final;
+  std::vector<tesseract::common::LinkId> getTipLinkIds() const override final;
   std::string getSolverName() const override final;
   InverseKinematics::UPtr clone() const override final;
 

--- a/tesseract_kinematics/trac-ik/include/tesseract_trac_ik/trac-ik/trac-ik_inv_kin_chain.h
+++ b/tesseract_kinematics/trac-ik/include/tesseract_trac_ik/trac-ik/trac-ik_inv_kin_chain.h
@@ -95,7 +95,7 @@ public:
                     TRAC_IK::SolveType solve_type = SOLVE_TYPE);
 
   void calcInvKin(IKSolutions& solutions,
-                  const tesseract::common::TransformMap& tip_link_poses,
+                  const tesseract::common::LinkIdTransformMap& tip_link_poses,
                   const Eigen::Ref<const Eigen::VectorXd>& seed) const override final;
 
   std::vector<std::string> getJointNames() const override final;

--- a/tesseract_kinematics/trac-ik/include/tesseract_trac_ik/trac-ik/trac-ik_inv_kin_chain.h
+++ b/tesseract_kinematics/trac-ik/include/tesseract_trac_ik/trac-ik/trac-ik_inv_kin_chain.h
@@ -101,7 +101,7 @@ public:
   std::vector<tesseract::common::JointId> getJointIds() const override final;
   Eigen::Index numJoints() const override final;
   tesseract::common::LinkId getBaseLinkId() const override final;
-  tesseract::common::LinkId getWorkingFrameId() const override final;
+  tesseract::common::LinkId getWorkingFrame() const override final;
   std::vector<tesseract::common::LinkId> getTipLinkIds() const override final;
   std::string getSolverName() const override final;
   InverseKinematics::UPtr clone() const override final;

--- a/tesseract_kinematics/trac-ik/include/tesseract_trac_ik/trac-ik/trac-ik_inv_kin_chain.h
+++ b/tesseract_kinematics/trac-ik/include/tesseract_trac_ik/trac-ik/trac-ik_inv_kin_chain.h
@@ -49,10 +49,6 @@ static const TRAC_IK::SolveType SOLVE_TYPE = TRAC_IK::SolveType::Speed;
 class TracIKInvKinChain : public InverseKinematics
 {
 public:
-  // LCOV_EXCL_START
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  // LCOV_EXCL_STOP
-
   using Ptr = std::shared_ptr<TracIKInvKinChain>;
   using ConstPtr = std::shared_ptr<const TracIKInvKinChain>;
   using UPtr = std::unique_ptr<TracIKInvKinChain>;
@@ -68,13 +64,13 @@ public:
    * @brief Construct Inverse Kinematics as chain
    * Creates a inverse kinematic chain object
    * @param scene_graph The Tesseract Scene Graph
-   * @param base_link The name of the base link for the kinematic chain
-   * @param tip_link The name of the tip link for the kinematic chain
+   * @param base_link The id of the base link for the kinematic chain
+   * @param tip_link The id of the tip link for the kinematic chain
    * @param solver_name The name of the kinematic chain
    */
   TracIKInvKinChain(const tesseract::scene_graph::SceneGraph& scene_graph,
-                    tesseract::common::LinkId base_link,
-                    tesseract::common::LinkId tip_link,
+                    const tesseract::common::LinkId& base_link,
+                    const tesseract::common::LinkId& tip_link,
                     std::string solver_name = TRACIK_INV_KIN_CHAIN_SOLVER_NAME,
                     double max_time = MAX_TIME,
                     double epsilon = EPSILON,

--- a/tesseract_kinematics/trac-ik/include/tesseract_trac_ik/trac-ik/trac-ik_inv_kin_chain.h
+++ b/tesseract_kinematics/trac-ik/include/tesseract_trac_ik/trac-ik/trac-ik_inv_kin_chain.h
@@ -73,8 +73,8 @@ public:
    * @param solver_name The name of the kinematic chain
    */
   TracIKInvKinChain(const tesseract::scene_graph::SceneGraph& scene_graph,
-                    const std::string& base_link,
-                    const std::string& tip_link,
+                    tesseract::common::LinkId base_link,
+                    tesseract::common::LinkId tip_link,
                     std::string solver_name = TRACIK_INV_KIN_CHAIN_SOLVER_NAME,
                     double max_time = MAX_TIME,
                     double epsilon = EPSILON,
@@ -88,7 +88,7 @@ public:
    * @param solver_name The solver name of the kinematic chain
    */
   TracIKInvKinChain(const tesseract::scene_graph::SceneGraph& scene_graph,
-                    const std::vector<std::pair<std::string, std::string> >& chains,
+                    const std::vector<std::pair<tesseract::common::LinkId, tesseract::common::LinkId> >& chains,
                     std::string solver_name = TRACIK_INV_KIN_CHAIN_SOLVER_NAME,
                     double max_time = MAX_TIME,
                     double epsilon = EPSILON,

--- a/tesseract_kinematics/trac-ik/src/trac-ik_factory.cpp
+++ b/tesseract_kinematics/trac-ik/src/trac-ik_factory.cpp
@@ -36,8 +36,8 @@ TracIKInvKinChainFactory::create(const std::string& solver_name,
                                  const KinematicsPluginFactory& /*plugin_factory*/,
                                  const YAML::Node& config) const
 {
-  std::string base_link;
-  std::string tip_link;
+  common::LinkId base_link;
+  common::LinkId tip_link;
   double max_time = MAX_TIME;
   double epsilon = EPSILON;
   TRAC_IK::SolveType solve_type = SOLVE_TYPE;
@@ -45,12 +45,12 @@ TracIKInvKinChainFactory::create(const std::string& solver_name,
   try
   {
     if (const YAML::Node& n = config["base_link"])
-      base_link = n.as<std::string>();
+      base_link = common::LinkId(n.as<std::string>());
     else
       throw std::runtime_error("TracIKInvKinChainFactory, missing 'base_link' entry");
 
     if (const YAML::Node& n = config["tip_link"])
-      tip_link = n.as<std::string>();
+      tip_link = common::LinkId(n.as<std::string>());
     else
       throw std::runtime_error("TracIKInvKinChainFactory, missing 'tip_link' entry");
 

--- a/tesseract_kinematics/trac-ik/src/trac-ik_inv_kin_chain.cpp
+++ b/tesseract_kinematics/trac-ik/src/trac-ik_inv_kin_chain.cpp
@@ -127,11 +127,11 @@ void TracIKInvKinChain::calcInvKinHelper(IKSolutions& solutions,
 }
 
 void TracIKInvKinChain::calcInvKin(IKSolutions& solutions,
-                                   const tesseract::common::TransformMap& tip_link_poses,
+                                   const tesseract::common::LinkIdTransformMap& tip_link_poses,
                                    const Eigen::Ref<const Eigen::VectorXd>& seed) const
 {
-  assert(tip_link_poses.find(kdl_data_.tip_link_name) != tip_link_poses.end());
-  calcInvKinHelper(solutions, tip_link_poses.at(kdl_data_.tip_link_name), seed);
+  assert(tip_link_poses.find(tesseract::common::LinkId::fromName(kdl_data_.tip_link_name)) != tip_link_poses.end());
+  calcInvKinHelper(solutions, tip_link_poses.at(tesseract::common::LinkId::fromName(kdl_data_.tip_link_name)), seed);
 }
 
 std::vector<std::string> TracIKInvKinChain::getJointNames() const { return kdl_data_.joint_names; }

--- a/tesseract_kinematics/trac-ik/src/trac-ik_inv_kin_chain.cpp
+++ b/tesseract_kinematics/trac-ik/src/trac-ik_inv_kin_chain.cpp
@@ -130,19 +130,19 @@ void TracIKInvKinChain::calcInvKin(IKSolutions& solutions,
                                    const tesseract::common::LinkIdTransformMap& tip_link_poses,
                                    const Eigen::Ref<const Eigen::VectorXd>& seed) const
 {
-  assert(tip_link_poses.find(tesseract::common::LinkId::fromName(kdl_data_.tip_link_name)) != tip_link_poses.end());
-  calcInvKinHelper(solutions, tip_link_poses.at(tesseract::common::LinkId::fromName(kdl_data_.tip_link_name)), seed);
+  assert(tip_link_poses.find(kdl_data_.tip_link_id) != tip_link_poses.end());
+  calcInvKinHelper(solutions, tip_link_poses.at(kdl_data_.tip_link_id), seed);
 }
 
-std::vector<std::string> TracIKInvKinChain::getJointNames() const { return kdl_data_.joint_names; }
+std::vector<tesseract::common::JointId> TracIKInvKinChain::getJointIds() const { return kdl_data_.joint_ids; }
 
 Eigen::Index TracIKInvKinChain::numJoints() const { return kdl_data_.robot_chain.getNrOfJoints(); }
 
-std::string TracIKInvKinChain::getBaseLinkName() const { return kdl_data_.base_link_name; }
+tesseract::common::LinkId TracIKInvKinChain::getBaseLinkId() const { return kdl_data_.base_link_id; }
 
-std::string TracIKInvKinChain::getWorkingFrame() const { return kdl_data_.base_link_name; }
+tesseract::common::LinkId TracIKInvKinChain::getWorkingFrameId() const { return kdl_data_.base_link_id; }
 
-std::vector<std::string> TracIKInvKinChain::getTipLinkNames() const { return { kdl_data_.tip_link_name }; }
+std::vector<tesseract::common::LinkId> TracIKInvKinChain::getTipLinkIds() const { return { kdl_data_.tip_link_id }; }
 
 std::string TracIKInvKinChain::getSolverName() const { return solver_name_; }
 

--- a/tesseract_kinematics/trac-ik/src/trac-ik_inv_kin_chain.cpp
+++ b/tesseract_kinematics/trac-ik/src/trac-ik_inv_kin_chain.cpp
@@ -38,12 +38,13 @@ namespace tesseract::kinematics
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
-TracIKInvKinChain::TracIKInvKinChain(const tesseract::scene_graph::SceneGraph& scene_graph,
-                                     const std::vector<std::pair<std::string, std::string>>& chains,
-                                     std::string solver_name,
-                                     double max_time,
-                                     double epsilon,
-                                     TRAC_IK::SolveType solve_type)
+TracIKInvKinChain::TracIKInvKinChain(
+    const tesseract::scene_graph::SceneGraph& scene_graph,
+    const std::vector<std::pair<tesseract::common::LinkId, tesseract::common::LinkId>>& chains,
+    std::string solver_name,
+    double max_time,
+    double epsilon,
+    TRAC_IK::SolveType solve_type)
   : max_time_(max_time), epsilon_(epsilon), solve_type_(solve_type), solver_name_(std::move(solver_name))
 {
   if (!scene_graph.getLink(scene_graph.getRoot()))
@@ -58,8 +59,8 @@ TracIKInvKinChain::TracIKInvKinChain(const tesseract::scene_graph::SceneGraph& s
 }
 
 TracIKInvKinChain::TracIKInvKinChain(const tesseract::scene_graph::SceneGraph& scene_graph,
-                                     const std::string& base_link,
-                                     const std::string& tip_link,
+                                     tesseract::common::LinkId base_link,
+                                     tesseract::common::LinkId tip_link,
                                      std::string solver_name,
                                      double max_time,
                                      double epsilon,

--- a/tesseract_kinematics/trac-ik/src/trac-ik_inv_kin_chain.cpp
+++ b/tesseract_kinematics/trac-ik/src/trac-ik_inv_kin_chain.cpp
@@ -141,7 +141,7 @@ Eigen::Index TracIKInvKinChain::numJoints() const { return kdl_data_.robot_chain
 
 tesseract::common::LinkId TracIKInvKinChain::getBaseLinkId() const { return kdl_data_.base_link_id; }
 
-tesseract::common::LinkId TracIKInvKinChain::getWorkingFrameId() const { return kdl_data_.base_link_id; }
+tesseract::common::LinkId TracIKInvKinChain::getWorkingFrame() const { return kdl_data_.base_link_id; }
 
 std::vector<tesseract::common::LinkId> TracIKInvKinChain::getTipLinkIds() const { return { kdl_data_.tip_link_id }; }
 

--- a/tesseract_kinematics/trac-ik/src/trac-ik_inv_kin_chain.cpp
+++ b/tesseract_kinematics/trac-ik/src/trac-ik_inv_kin_chain.cpp
@@ -59,8 +59,8 @@ TracIKInvKinChain::TracIKInvKinChain(
 }
 
 TracIKInvKinChain::TracIKInvKinChain(const tesseract::scene_graph::SceneGraph& scene_graph,
-                                     tesseract::common::LinkId base_link,
-                                     tesseract::common::LinkId tip_link,
+                                     const tesseract::common::LinkId& base_link,
+                                     const tesseract::common::LinkId& tip_link,
                                      std::string solver_name,
                                      double max_time,
                                      double epsilon,


### PR DESCRIPTION
Requires https://github.com/tesseract-robotics/tesseract/pull/1274 and https://github.com/tesseract-robotics/tesseract_planning/pull/734