### PR TITLE
Add Manip3 solve type and require trac_ik_lib 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ kinematic_plugins:
 ### Parameters
 
 - _epsilon:_ Maximum deviation between target pose and IK solution.
-- _max_time:_ Maximum calculation time per IK query (seconds). Speed returns as soon as a solution is found or this deadline is hit; Distance/Manip1/Manip2 keep searching until the deadline and return the best solution found.
-- _solve_type:_ (Speed/Distance/Manip1/Manip2) Speed: return first feasible solution, Distance: return solution closest to seed, Manip1/Manip2: use one of two manipulabilty metrics to find the best solution.
+- _max_time:_ Maximum calculation time per IK query (seconds). Speed returns as soon as a solution is found or this deadline is hit; Distance/Manip1/Manip2/Manip3 keep searching until the deadline and return the best solution found.
+- _solve_type:_ (Speed/Distance/Manip1/Manip2/Manip3) Speed: return first feasible solution, Distance: return solution closest to seed, Manip1/Manip2/Manip3: use one of three manipulabilty metrics to find the best solution (Manip1 maximizes the product of the Jacobian's singular values, Manip2 its inverse condition number, Manip3 its smallest singular value).
 - _bounds:_ Per-axis Cartesian tolerance applied to every IK query, as a 6-element sequence `[vx, vy, vz, rx, ry, rz]` (linear x/y/z then angular x/y/z, in meters and radians). Any solution whose pose lies within these bounds of the target is accepted. All zeros (default) disables tolerance and falls back to `epsilon`.
 
 #### Parameter defaults

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This plugin is not included in the main Tesseract repository, as [trac_ik_lib](h
 ## Usage
 
 - Clone this repo to the `src` folder of your project.
+- Build `trac_ik_lib` **2.2.0 or newer** from source (see `dependencies.repos`). The ROS binary releases are too old
+  (Jazzy ships 2.0.2): 2.1.0 replaced the constructor's `rclcpp::Node::SharedPtr` with an `rclcpp::Logger`, and 2.2.0
+  added `Manip3`. Uninstall `ros-<distro>-trac-ik-lib` or make sure the workspace overlay is sourced after
+  `/opt/ros/<distro>/setup.bash`, so both the build and the loader pick up the source build.
 - Add `tesseract_trac_ik_trac-ik_factory` to the `search_libraries` of your robot's `kinematic_plugins.yml`.
 - Add Trac-IK to the `inv_kin_plugins` of your robot manipulator:
 

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,4 +1,4 @@
 - git:
     local-name: trac_ik
-    uri: https://github.com/aprotyas/trac_ik.git
-    version: ros2
+    uri: https://github.com/traclabs/trac_ik
+    version: rolling

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
   <build_depend>eigen</build_depend>
   <build_export_depend>eigen</build_export_depend>
   <depend>libconsole-bridge-dev</depend>
-  <depend>trac_ik_lib</depend>
+  <depend version_gte="2.2.0">trac_ik_lib</depend>
 
   <test_depend>gtest</test_depend>
   <test_depend>tesseract_support</test_depend>

--- a/tesseract_kinematics/trac-ik/CMakeLists.txt
+++ b/tesseract_kinematics/trac-ik/CMakeLists.txt
@@ -1,4 +1,7 @@
-find_package(trac_ik_lib REQUIRED)
+# Requires 2.1.0+ for the node-less constructor (the pre-2.1.0 one takes an rclcpp::Node::SharedPtr) and 2.2.0+ for
+# SolveType::Manip3. Pinning makes CMake skip an older prefix (e.g. the ROS binary release, 2.0.2 on Jazzy) rather
+# than fail later with a confusing overload error, or link against a 2.1.x .so where Manip3 silently hits default.
+find_package(trac_ik_lib 2.2.0 REQUIRED)
 # When integrating into tesseract_kinematics remove next line
 find_package(tesseract REQUIRED COMPONENTS kinematics kinematics_kdl)
 
@@ -74,7 +77,7 @@ configure_component(
   COMPONENT trac-ik
   NAMESPACE tesseract
   TARGETS ${PROJECT_NAME}_trac-ik ${PROJECT_NAME}_trac-ik_factory
-  DEPENDENCIES trac_ik_lib "tesseract_kinematics COMPONENTS core")
+  DEPENDENCIES "trac_ik_lib 2.2.0" "tesseract_kinematics COMPONENTS core")
 
 if(TESSERACT_PACKAGE)
   cpack_component(

--- a/tesseract_kinematics/trac-ik/include/tesseract_trac_ik/trac-ik/trac-ik_inv_kin_chain.h
+++ b/tesseract_kinematics/trac-ik/include/tesseract_trac_ik/trac-ik/trac-ik_inv_kin_chain.h
@@ -70,7 +70,7 @@ public:
    * @param solver_name The name of the kinematic chain
    * @param max_time Per-query deadline in seconds
    * @param epsilon Maximum deviation between target pose and IK solution
-   * @param solve_type Solution selection strategy (Speed, Distance, Manip1, Manip2)
+   * @param solve_type Solution selection strategy (Speed, Distance, Manip1, Manip2, Manip3)
    * @param bounds Per-axis Cartesian tolerance [vx, vy, vz, rx, ry, rz]; zero falls back to @p epsilon
    */
   TracIKInvKinChain(const tesseract::scene_graph::SceneGraph& scene_graph,
@@ -90,7 +90,7 @@ public:
    * @param solver_name The solver name of the kinematic chain
    * @param max_time Per-query deadline in seconds
    * @param epsilon Maximum deviation between target pose and IK solution
-   * @param solve_type Solution selection strategy (Speed, Distance, Manip1, Manip2)
+   * @param solve_type Solution selection strategy (Speed, Distance, Manip1, Manip2, Manip3)
    * @param bounds Per-axis Cartesian tolerance [vx, vy, vz, rx, ry, rz]; zero falls back to @p epsilon
    */
   TracIKInvKinChain(const tesseract::scene_graph::SceneGraph& scene_graph,

--- a/tesseract_kinematics/trac-ik/src/trac-ik_factory.cpp
+++ b/tesseract_kinematics/trac-ik/src/trac-ik_factory.cpp
@@ -86,6 +86,10 @@ TracIKInvKinChainFactory::create(const std::string& solver_name,
         {
           solve_type = TRAC_IK::SolveType::Manip2;
         }
+        else if (type == "Manip3")
+        {
+          solve_type = TRAC_IK::SolveType::Manip3;
+        }
         else
         {
           throw std::runtime_error("TracIKInvKinChainFactory, 'params' entry 'solve_type' invalid");


### PR DESCRIPTION
Adds the `Manip3` solve type introduced in trac_ik_lib 2.2.0, and declares the trac_ik_lib version this plugin actually needs.

## Manip3

`SolveType::Manip3` selects the solution maximizing the Jacobian's smallest singular value, alongside the existing Manip1 (product of the singular values) and Manip2 (their ratio). It is wired through the YAML `solve_type` parser; `solve_type_` was already passed straight to `TRAC_IK::TRAC_IK` and copied in the copy constructor, so nothing else needed to change.

## trac_ik_lib version requirement

The plugin has needed trac_ik_lib 2.1.0 since it started using the node-less `TRAC_IK` constructor, but never declared it — the 2.0.x constructor takes an `rclcpp::Node::SharedPtr` as its first argument. With an older prefix on the search path (the ROS binary release is 2.0.2 on Jazzy) the build picked that one up and failed with a confusing overload error rather than a version error.

`find_package(trac_ik_lib 2.2.0 REQUIRED)` makes CMake skip an incompatible prefix and select a satisfying one even when the older prefix comes first in `CMAKE_PREFIX_PATH`. The constraint is propagated to consumers through the exported config (`find_dependency(trac_ik_lib 2.2.0)`) and declared in `package.xml` via `version_gte`.

`dependencies.repos` now points at `traclabs/trac_ik` `rolling`, which carries 2.2.0.

One caveat worth flagging for Jazzy users: `traclabs/trac_ik` `rolling` includes `<urdf/model.hpp>`, which exists on Kilted and Rolling but not on Jazzy, where urdf still ships only `model.h`. Building that branch on Jazzy needs a fix upstream in trac_ik.
